### PR TITLE
Corrected link text - changed "nternet Archive" to "Internet Archive"

### DIFF
--- a/content/02-terms/cursive-recognizer/cursive-recognizer.txt
+++ b/content/02-terms/cursive-recognizer/cursive-recognizer.txt
@@ -14,7 +14,7 @@ Also referred to as the [connected recognizer](/terms/connected-recognizer).
 
 ## Additional Information
 
-[nternet Archive: Catamount: Handwriting Tips for Newton Power Users](https://web.archive.org/web/20160319221639/http://www.catamount.com/HWRTips/HWRTips.html)
+[Internet Archive: Catamount: Handwriting Tips for Newton Power Users](https://web.archive.org/web/20160319221639/http://www.catamount.com/HWRTips/HWRTips.html)
 
 ----
 

--- a/content/02-terms/gesture/gesture.txt
+++ b/content/02-terms/gesture/gesture.txt
@@ -14,7 +14,7 @@ The [Graffiti](/terms/graffiti) input system is also based on gestures.
 
 ## Additional Information
 
-[nternet Archive: Catamount: Handwriting Tips for Newton Power Users](https://web.archive.org/web/20160319221639/http://www.catamount.com/HWRTips/HWRTips.html)
+[Internet Archive: Catamount: Handwriting Tips for Newton Power Users](https://web.archive.org/web/20160319221639/http://www.catamount.com/HWRTips/HWRTips.html)
 
 ----
 

--- a/content/02-terms/paragraph/paragraph.txt
+++ b/content/02-terms/paragraph/paragraph.txt
@@ -12,7 +12,7 @@ Another name for the cursive (or connected) recognizer according to the [Catamou
 
 ## Additional Information
 
-[nternet Archive: Catamount: Handwriting Tips for Newton Power Users](https://web.archive.org/web/20160319221639/http://www.catamount.com/HWRTips/HWRTips.html)
+[Internet Archive: Catamount: Handwriting Tips for Newton Power Users](https://web.archive.org/web/20160319221639/http://www.catamount.com/HWRTips/HWRTips.html)
 
 ----
 

--- a/content/02-terms/print-recognizer/print-recognizer.txt
+++ b/content/02-terms/print-recognizer/print-recognizer.txt
@@ -14,7 +14,7 @@ Also referred to as the [disconnected recognizer](/terms/disconnected-recognizer
 
 ## Additional Information
 
-[nternet Archive: Catamount: Handwriting Tips for Newton Power Users](https://web.archive.org/web/20160319221639/http://www.catamount.com/HWRTips/HWRTips.html)
+[Internet Archive: Catamount: Handwriting Tips for Newton Power Users](https://web.archive.org/web/20160319221639/http://www.catamount.com/HWRTips/HWRTips.html)
 
 ----
 


### PR DESCRIPTION
Noticed this minor typo in the link text to Catamount HWR tips.  Looks like a copy/paste bug.